### PR TITLE
sd8887-mrvl/sd8887-mrvl.bb: Use new source repo for SRC_URI

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-kernel/sd8887-mrvl/sd8887-mrvl.bb
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/sd8887-mrvl/sd8887-mrvl.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${WORKDIR}/COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca
 inherit module
 
 SRC_URI = " \
-    git://git@github.com/resin-io/sd8887-mrvl.git;protocol=ssh;branch=raspbian-build \
+    git://git@github.com/balena-io/sd8887-mrvl.git;protocol=ssh;branch=raspbian-build \
     file://COPYING \
 "
 


### PR DESCRIPTION
This was moved when renamed from resin to balena

Changelog-entry: Use new balena source repo for SRC_URI
Signed-off-by: Florin Sarbu <florin@balena.io>