### PR TITLE
u-boot: Set autoboot with no delay, with no check for abort

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot/rpi-Add-autoboot-configuration-in-defconfigs.patch
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot/rpi-Add-autoboot-configuration-in-defconfigs.patch
@@ -6,92 +6,67 @@ Subject: rpi: Add autoboot configuration in defconfigs
 Signed-off-by: Zubair Lutfullah Kakakhel <zubair@resin.io>
 Upstream-Status: Inappropriate [configuration]
 ---
- configs/rpi_0_w_defconfig   | 8 ++++++++
- configs/rpi_2_defconfig     | 8 ++++++++
- configs/rpi_3_32b_defconfig | 8 ++++++++
- configs/rpi_3_defconfig     | 8 ++++++++
- configs/rpi_defconfig       | 8 ++++++++
- 5 files changed, 40 insertions(+)
+ configs/rpi_0_w_defconfig   | 3 +++
+ configs/rpi_2_defconfig     | 3 +++
+ configs/rpi_3_32b_defconfig | 3 +++
+ configs/rpi_3_defconfig     | 3 +++
+ configs/rpi_defconfig       | 3 +++
+ 5 files changed, 15 insertions(+)
 
 diff --git a/configs/rpi_0_w_defconfig b/configs/rpi_0_w_defconfig
 index fcc2ae6..5c24c17 100644
 --- a/configs/rpi_0_w_defconfig
 +++ b/configs/rpi_0_w_defconfig
-@@ -36,3 +36,11 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -36,3 +36,6 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y
-+CONFIG_AUTOBOOT=y
 +CONFIG_AUTOBOOT_KEYED=y
-+CONFIG_AUTOBOOT_STOP_STR="\x0b"
-+CONFIG_AUTOBOOT_KEYED_CTRLC=y
-+CONFIG_AUTOBOOT_PROMPT="autoboot in 1 second (hold 'CTRL^C' to abort)\n"
-+CONFIG_BOOT_RETRY_TIME=15
-+CONFIG_RESET_TO_RETRY=y
-+CONFIG_BOOTDELAY=1
++CONFIG_AUTOBOOT_KEYED_CTRLC=n
++CONFIG_BOOTDELAY=-2
 diff --git a/configs/rpi_2_defconfig b/configs/rpi_2_defconfig
 index 204af74..45b6625 100644
 --- a/configs/rpi_2_defconfig
 +++ b/configs/rpi_2_defconfig
-@@ -36,3 +36,11 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -36,3 +36,6 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y
-+CONFIG_AUTOBOOT=y
 +CONFIG_AUTOBOOT_KEYED=y
-+CONFIG_AUTOBOOT_STOP_STR="\x0b"
-+CONFIG_AUTOBOOT_KEYED_CTRLC=y
-+CONFIG_AUTOBOOT_PROMPT="autoboot in 1 second (hold 'CTRL^C' to abort)\n"
-+CONFIG_BOOT_RETRY_TIME=15
-+CONFIG_RESET_TO_RETRY=y
-+CONFIG_BOOTDELAY=1
++CONFIG_AUTOBOOT_KEYED_CTRLC=n
++CONFIG_BOOTDELAY=-2
 diff --git a/configs/rpi_3_32b_defconfig b/configs/rpi_3_32b_defconfig
 index 9e142ca..dacf8c0 100644
 --- a/configs/rpi_3_32b_defconfig
 +++ b/configs/rpi_3_32b_defconfig
-@@ -39,3 +39,11 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -39,3 +39,6 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y
-+CONFIG_AUTOBOOT=y
 +CONFIG_AUTOBOOT_KEYED=y
-+CONFIG_AUTOBOOT_STOP_STR="\x0b"
-+CONFIG_AUTOBOOT_KEYED_CTRLC=y
-+CONFIG_AUTOBOOT_PROMPT="autoboot in 1 second (hold 'CTRL^C' to abort)\n"
-+CONFIG_BOOT_RETRY_TIME=15
-+CONFIG_RESET_TO_RETRY=y
-+CONFIG_BOOTDELAY=1
++CONFIG_AUTOBOOT_KEYED_CTRLC=n
++CONFIG_BOOTDELAY=-2
 diff --git a/configs/rpi_3_defconfig b/configs/rpi_3_defconfig
 index f46e504..4ef87dc 100644
 --- a/configs/rpi_3_defconfig
 +++ b/configs/rpi_3_defconfig
-@@ -39,3 +39,11 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -39,3 +39,6 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y
-+CONFIG_AUTOBOOT=y
 +CONFIG_AUTOBOOT_KEYED=y
-+CONFIG_AUTOBOOT_STOP_STR="\x0b"
-+CONFIG_AUTOBOOT_KEYED_CTRLC=y
-+CONFIG_AUTOBOOT_PROMPT="autoboot in 1 second (hold 'CTRL^C' to abort)\n"
-+CONFIG_BOOT_RETRY_TIME=15
-+CONFIG_RESET_TO_RETRY=y
-+CONFIG_BOOTDELAY=1
++CONFIG_AUTOBOOT_KEYED_CTRLC=n
++CONFIG_BOOTDELAY=-2
 diff --git a/configs/rpi_defconfig b/configs/rpi_defconfig
 index 82c90d4..aa0de2f 100644
 --- a/configs/rpi_defconfig
 +++ b/configs/rpi_defconfig
-@@ -36,3 +36,11 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -36,3 +36,6 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y
-+CONFIG_AUTOBOOT=y
 +CONFIG_AUTOBOOT_KEYED=y
-+CONFIG_AUTOBOOT_STOP_STR="\x0b"
-+CONFIG_AUTOBOOT_KEYED_CTRLC=y
-+CONFIG_AUTOBOOT_PROMPT="autoboot in 1 second (hold 'CTRL^C' to abort)\n"
-+CONFIG_BOOT_RETRY_TIME=15
-+CONFIG_RESET_TO_RETRY=y
-+CONFIG_BOOTDELAY=1
++CONFIG_AUTOBOOT_KEYED_CTRLC=n
++CONFIG_BOOTDELAY=-2
 --
 2.7.4

--- a/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -9,8 +9,9 @@ SRC_URI_remove = " file://0002-rpi_0_w-Add-configs-consistent-with-RpI3.patch "
 # Remove patch inherited from meta-resin. This needs to be rebased for v2018.07
 SRC_URI_remove = " file://resin-specific-env-integration-kconfig.patch "
 
-SRC_URI += "file://rpi-Add-autoboot-configuration-in-defconfigs.patch \
-            file://0001-Integrate-machine-independent-resin-environment-conf.patch \
-            file://rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch \
-            file://bootcount-Add-support-to-write-bootcount-to-any-file.patch \
-            "
+SRC_URI += " \
+    file://rpi-Add-autoboot-configuration-in-defconfigs.patch \
+    file://0001-Integrate-machine-independent-resin-environment-conf.patch \
+    file://rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch \
+    file://bootcount-Add-support-to-write-bootcount-to-any-file.patch \
+"


### PR DESCRIPTION
We disable autoboot stopping by pressing any key combinations because
there are cases where other ICs are connected to the pi's UART and it
is possible that the other ICs are sending the particular autoboot
stop combination over UART.

Changelog-entry: Set autoboot with no delay, with no check for abort
Signed-off-by: Florin Sarbu <florin@balena.io>